### PR TITLE
Fix MacOS library path

### DIFF
--- a/lib/cl11.js
+++ b/lib/cl11.js
@@ -12,7 +12,7 @@ function CL11() {
     this.types = types;
     this.defs = defs;
     this.version = 1.1;
-    this.libName = (process.platform === "win32" || process.platform === "darwin") ? "OpenCL" : "libOpenCL.so";
+    this.libName = (process.platform === "win32") ? "OpenCL" : (process.platform === "darwin") ? "/System/Library/Frameworks/OpenCL.framework/OpenCL" : "libOpenCL.so";
     this.imports = new ffi.Library(this.libName,
         {
             /* Platform APIs */


### PR DESCRIPTION
Fixes module to find the OpenCL framework on MacOS/OS X by pointing to the system OpenCL path when platform is `darwin`

Should fix issues #22 and #10 