### PR TITLE
Add basic Travis CI config and setup script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,10 @@ matrix:
       dist: trusty
       node_js: "6"
       compiler:
-        - gcc
-        - c++
         - g++
     - os: osx
       osx_image: xcode7.3
       node_js: "6"
-      compiler:
-        - clang
+
 before_install:
   - ./.travis/setup.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,13 @@ matrix:
       dist: trusty
       node_js: "6"
       compiler:
+        - gcc
+        - c++
         - g++
     - os: osx
       osx_image: xcode7.3
       node_js: "6"
-
+      compiler:
+        - clang
 before_install:
   - ./.travis/setup.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,18 @@
- language: node_js
- node_js:
-   - "0.10"
+language: node_js
+sudo: required
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      node_js: "6"
+      compiler:
+        - gcc
+        - c++
+        - g++
+    - os: osx
+      osx_image: xcode7.3
+      node_js: "6"
+      compiler:
+        - clang
 before_install:
-   - sudo apt-get update -qq
-   - sudo apt-get install -qq fglrx=2:8.960-0ubuntu1 opencl-headers
+  - ./.travis/setup.sh

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -1,16 +1,25 @@
 #!/bin/bash
 
 if [[ $TRAVIS_OS_NAME == 'linux' ]]; then
+
     # Install some custom requirements on Linux
     echo "Setting up Ubuntu OpenCL Prerequisites"
+
+    # apt-get setup and toolset installation
     sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     sudo apt-get update -qq -y
-    sudo apt-get install -qq mesa-common-dev alien libnuma1 opencl-headers git
+    sudo apt-get install -qq mesa-common-dev alien libnuma1 opencl-headers
     sudo apt-get install -qq g++-4.8
+
+    # setup compiler
     export CXX="g++-4.8"
     sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+
+    # download and unpack base opencl Intel drivers
     wget http://registrationcenter.intel.com/irc_nas/4181/opencl_runtime_14.2_x64_4.5.0.8.tgz
     tar -xvf opencl_runtime_14.2_x64_4.5.0.8.tgz
+
+    # convert opencl drivers from rpm to deb package and install
     cd pset_opencl_runtime_14.1_x64_4.5.0.8/rpm
     for f in *.rpm; do
         fakeroot alien --to-deb $f
@@ -18,14 +27,19 @@ if [[ $TRAVIS_OS_NAME == 'linux' ]]; then
     for f in *.deb; do
         sudo dpkg -i $f
     done
+
+    # link drivers
     sudo mkdir /etc/OpenCL
     sudo mkdir /etc/OpenCL/vendors
     sudo ln -s /opt/intel/opencl-1.2-4.5.0.8/etc/intel64.icd /etc/OpenCL/vendors/intel64.icd
     sudo ln -s /opt/intel/opencl-1.2-4.5.0.8/lib64/libOpenCL.so /usr/lib/libOpenCL.so
     sudo ln -s /opt/intel/opencl-1.2-4.5.0.8/lib64/libOpenCL.so.1 /usr/lib/libOpenCL.so.1
     sudo ldconfig
+
+    # wrap up
     cd ../..
 else
+
     # Install some custom requirements on OS X
     echo "No OSX OpenCL Prerequisites"
 fi

--- a/.travis/setup.sh
+++ b/.travis/setup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+if [[ $TRAVIS_OS_NAME == 'linux' ]]; then
+    # Install some custom requirements on Linux
+    echo "Setting up Ubuntu OpenCL Prerequisites"
+    sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    sudo apt-get update -qq -y
+    sudo apt-get install -qq mesa-common-dev alien libnuma1 opencl-headers git
+    sudo apt-get install -qq g++-4.8
+    export CXX="g++-4.8"
+    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+    wget http://registrationcenter.intel.com/irc_nas/4181/opencl_runtime_14.2_x64_4.5.0.8.tgz
+    tar -xvf opencl_runtime_14.2_x64_4.5.0.8.tgz
+    cd pset_opencl_runtime_14.1_x64_4.5.0.8/rpm
+    for f in *.rpm; do
+        fakeroot alien --to-deb $f
+    done
+    for f in *.deb; do
+        sudo dpkg -i $f
+    done
+    sudo mkdir /etc/OpenCL
+    sudo mkdir /etc/OpenCL/vendors
+    sudo ln -s /opt/intel/opencl-1.2-4.5.0.8/etc/intel64.icd /etc/OpenCL/vendors/intel64.icd
+    sudo ln -s /opt/intel/opencl-1.2-4.5.0.8/lib64/libOpenCL.so /usr/lib/libOpenCL.so
+    sudo ln -s /opt/intel/opencl-1.2-4.5.0.8/lib64/libOpenCL.so.1 /usr/lib/libOpenCL.so.1
+    sudo ldconfig
+    cd ../..
+else
+    # Install some custom requirements on OS X
+    echo "No OSX OpenCL Prerequisites"
+fi

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/unbornchikken/NOOOCL.svg?branch=master)](https://travis-ci.org/unbornchikken/NOOOCL)
+
 # TOC
 
 <!-- TOC -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nooocl",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "author": "Gábor Mező aka unbornchikken",
   "description": "NOOOCL: Node.js Object Oriented OpenCL Bindings",
   "homepage": "https://github.com/unbornchikken/nooocl",

--- a/test/testHelpers.js
+++ b/test/testHelpers.js
@@ -22,18 +22,14 @@ var testHelpers = {
             version = version || CLHost.supportedVersions.cl11;
             var host = new CLHost(version);
             var cpuEnv = testHelpers.createEnvironment(host, "cpu");
-            var cpuTestResult = cpuEnv ? testMethod(cpuEnv) : Bluebird.resolve();
+            if (cpuEnv) {
+                return testMethod(cpuEnv);
+            }
             var gpuEnv = testHelpers.createEnvironment(host, "gpu");
             if (gpuEnv) {
-                return cpuTestResult.then(function () {
-                    return testMethod(gpuEnv);
-                });
+                return testMethod(gpuEnv);
             }
-            if (!gpuWarn) {
-                console.warn("GPU is not available!");
-                gpuWarn = true;
-            }
-            return cpuTestResult;
+            throw new Error("No OpenCL device available.");
         });
     },
     createEnvironment: function (host, hardware) {

--- a/test/toGray.cl
+++ b/test/toGray.cl
@@ -3,7 +3,7 @@ kernel void toGray(read_only image2d_t srcImg, write_only image2d_t dstImg)
   const sampler_t smp =
     CLK_NORMALIZED_COORDS_FALSE | //Natural coordinates
     CLK_ADDRESS_CLAMP_TO_EDGE | //Clamp to zeros
-    CLK_FILTER_LINEAR;
+    CLK_FILTER_NEAREST;
     
   int2 coord = (int2)(get_global_id(0), get_global_id(1));
   


### PR DESCRIPTION
This PR has basic config for OSX and Linux on Travis CI. Addresses unbornchikken/NOOOCL#24

OSX has OpenCL by default. Travis uses Ubuntu, and requires the (somewhat painful) installation of the Intel OpenCL drivers. Basic method replicated from [cdeterman/intel_opencl](https://github.com/cdeterman/intel_opencl).

The setup script may need to be modified to fix any driver installation issues that may or may not be present.

Works, but reveals failures on both OSX and Ubuntu. This should help with future troubleshooting.